### PR TITLE
Be able to customize hardcoded record["message"]

### DIFF
--- a/lib/fluent/plugin/out_azure_servicebus_queue.rb
+++ b/lib/fluent/plugin/out_azure_servicebus_queue.rb
@@ -13,6 +13,7 @@ module Fluent::Plugin
     config_param :accessKeyName, :string
     config_param :accessKeyValueFile, :string
     config_param :timeToLive, :integer
+    config_param :field, :string, :default => "message"
 
     # method for sync buffered output mode
     def write(chunk)
@@ -33,7 +34,7 @@ module Fluent::Plugin
       request['BrokerProperties'] = "{\"Label\":\"fluentd\",\"State\":\"Active\",\"TimeToLive\":#{timeToLive}}"
 
       chunk.each do |time, record|
-        request.body = record["message"]
+        request.body = record[field]
         https.request(request)
       end
     end

--- a/test/test_out_azure_servicebus_queue.rb
+++ b/test/test_out_azure_servicebus_queue.rb
@@ -42,6 +42,6 @@ class AzureServicebusQueueTest < Test::Unit::TestCase
         assert_equal 'send', d.instance.accessKeyName
         assert_equal '/etc/password/queuePassword', d.instance.accessKeyValueFile
         assert_equal 60, d.instance.timeToLive
-        assert_equal 'messages', d.instance.field
+        assert_equal 'message', d.instance.field
     end
 end

--- a/test/test_out_azure_servicebus_queue.rb
+++ b/test/test_out_azure_servicebus_queue.rb
@@ -18,6 +18,7 @@ class AzureServicebusQueueTest < Test::Unit::TestCase
         accessKeyName send
         accessKeyValueFile /etc/password/queuePassword
         format json
+        timeToLive 60
     !
 
     def create_driver(conf = CONFIG)
@@ -40,5 +41,7 @@ class AzureServicebusQueueTest < Test::Unit::TestCase
         assert_equal 'test_queue_name', d.instance.queueName
         assert_equal 'send', d.instance.accessKeyName
         assert_equal '/etc/password/queuePassword', d.instance.accessKeyValueFile
+        assert_equal 60, d.instance.timeToLive
+        assert_equal 'messages', d.instance.field
     end
 end


### PR DESCRIPTION
Sometimes `record["message"]` could change so it's necessary to add a variable to be able to customize that.