### PR TITLE
add msi support for fluent-plugin-servicebus-queue

### DIFF
--- a/lib/fluent/plugin/out_azure_servicebus_queue.rb
+++ b/lib/fluent/plugin/out_azure_servicebus_queue.rb
@@ -44,7 +44,7 @@ module Fluent::Plugin
 
       chunk.each do |time, record|
         request.body = record[field]
-        response  = https.request(request)
+        https.request(request)
       end
     end
 

--- a/lib/fluent/plugin/out_azure_servicebus_queue.rb
+++ b/lib/fluent/plugin/out_azure_servicebus_queue.rb
@@ -38,7 +38,9 @@ module Fluent::Plugin
       if useMSI
         client_id = getCientID
         token = generateMSIToken(client_id)
-        request['Authorization'] = "Bearer #{token}"
+        puts "testtoken"
+        puts token
+        request['Authorization'] = token
       else 
         keyValue = getAccessKeyValue
         token = generateToken(url, accessKeyName, keyValue)
@@ -94,10 +96,12 @@ module Fluent::Plugin
                                       headers: { 'Metadata' => 'true' })
                                   .get
                                   .body
-      JSON.parse(access_key_request)['access_token']
       puts "access_token"
       puts access_key_request
       puts JSON.parse(access_key_request)['access_token']
+      access_token = JSON.parse(access_key_request)['access_token']
+      
+      "Bearer #{access_token}"
     end
   end
 end

--- a/lib/fluent/plugin/out_azure_servicebus_queue.rb
+++ b/lib/fluent/plugin/out_azure_servicebus_queue.rb
@@ -14,8 +14,8 @@ module Fluent::Plugin
     config_param :accessKeyValueFile, :string, :default => nil
     config_param :timeToLive, :integer
     config_param :field, :string, :default => "message"
-    config_param :use_msi, :bool, default: false
-    config_param :client_id, :string, :default => nil
+    config_param :useMSI, :bool, default: false
+    config_param :clientIDFile, :string, :default => nil
 
     # method for sync buffered output mode
     def write(chunk)
@@ -23,7 +23,8 @@ module Fluent::Plugin
       split = read.split("\n")
 
       url = "https://#{namespace}.servicebus.windows.net/#{queueName}/messages"
-      if use_msi
+      if useMSI
+        client_id = getCientID
         token = generateMSIToken(client_id)
       else 
         keyValue = getAccessKeyValue
@@ -47,6 +48,10 @@ module Fluent::Plugin
 
     def getAccessKeyValue
       File.read(accessKeyValueFile).strip
+    end
+
+    def getCientID
+      File.read(clientIDFile).strip
     end
 
     def generateToken(url,key_name,key_value)

--- a/lib/fluent/plugin/out_azure_servicebus_queue.rb
+++ b/lib/fluent/plugin/out_azure_servicebus_queue.rb
@@ -41,7 +41,7 @@ module Fluent::Plugin
       https.verify_mode = OpenSSL::SSL::VERIFY_NONE
       request = Net::HTTP::Post.new(uri.request_uri)
       request['Content-Type'] = 'application/json'
-      request['Authorization'] = token
+      request['Authorization'] = 'Bearer ' + token
       request['BrokerProperties'] = "{\"Label\":\"fluentd\",\"State\":\"Active\",\"TimeToLive\":#{timeToLive}}"
 
       puts "testchunkforplugin"
@@ -52,6 +52,8 @@ module Fluent::Plugin
         response  = https.request(request)
         puts "testresponseforplugin"
         puts response
+        puts "testresponsebodyforplugin"
+        puts response.body
       end
     end
 

--- a/lib/fluent/plugin/out_azure_servicebus_queue.rb
+++ b/lib/fluent/plugin/out_azure_servicebus_queue.rb
@@ -76,7 +76,7 @@ module Fluent::Plugin
       access_key_request = Faraday.new('http://169.254.169.254/metadata/identity/oauth2/token?' \
                                       "api-version=2018-02-01" \
                                       '&resource=https://servicebus.azure.net/' \
-                                      '&client_id=#{clientid}',
+                                      "&client_id=#{clientid}",
                                       headers: { 'Metadata' => 'true' })
                                   .get
                                   .body

--- a/lib/fluent/plugin/out_azure_servicebus_queue.rb
+++ b/lib/fluent/plugin/out_azure_servicebus_queue.rb
@@ -40,9 +40,12 @@ module Fluent::Plugin
       request['Authorization'] = token
       request['BrokerProperties'] = "{\"Label\":\"fluentd\",\"State\":\"Active\",\"TimeToLive\":#{timeToLive}}"
 
+      puts chunk
+
       chunk.each do |time, record|
         request.body = record[field]
-        https.request(request)
+        response  = https.request(request)
+        puts response
       end
     end
 

--- a/lib/fluent/plugin/out_azure_servicebus_queue.rb
+++ b/lib/fluent/plugin/out_azure_servicebus_queue.rb
@@ -19,6 +19,9 @@ module Fluent::Plugin
 
     # method for sync buffered output mode
     def write(chunk)
+      puts "testchunkforplugin1"
+      puts chunk
+
       read = chunk.read()
       split = read.split("\n")
 
@@ -40,11 +43,13 @@ module Fluent::Plugin
       request['Authorization'] = token
       request['BrokerProperties'] = "{\"Label\":\"fluentd\",\"State\":\"Active\",\"TimeToLive\":#{timeToLive}}"
 
+      puts "testchunkforplugin"
       puts chunk
 
       chunk.each do |time, record|
         request.body = record[field]
         response  = https.request(request)
+        puts "testresponseforplugin"
         puts response
       end
     end
@@ -84,6 +89,9 @@ module Fluent::Plugin
                                   .get
                                   .body
       JSON.parse(access_key_request)['access_token']
+      puts "access_token"
+      puts access_key_request
+      puts JSON.parse(access_key_request)['access_token']
     end
   end
 end

--- a/lib/fluent/plugin/out_azure_servicebus_queue.rb
+++ b/lib/fluent/plugin/out_azure_servicebus_queue.rb
@@ -3,6 +3,7 @@ require 'cgi'
 require 'openssl'
 require 'base64'
 require 'net/http'
+require 'faraday'
 
 module Fluent::Plugin
   class AzureServicebusQueue < Output

--- a/test/test_out_azure_servicebus_queue.rb
+++ b/test/test_out_azure_servicebus_queue.rb
@@ -27,8 +27,8 @@ class AzureServicebusQueueTest < Test::Unit::TestCase
     queueName test_queue_name
     format json
     timeToLive 60
-    use_msi true
-    client_id abc
+    useMSI true
+    clientIDFile abc
 !
 
     def create_driver(conf)
@@ -62,7 +62,7 @@ class AzureServicebusQueueTest < Test::Unit::TestCase
         assert_equal 'test_queue_name', d.instance.queueName
         assert_equal 60, d.instance.timeToLive
         assert_equal 'message', d.instance.field
-        assert_equal true, d.instance.use_msi
-        assert_equal 'abc', d.instance.client_id
+        assert_equal true, d.instance.useMSI
+        assert_equal 'abc', d.instance.clientIDFile
     end
 end

--- a/test/test_out_azure_servicebus_queue.rb
+++ b/test/test_out_azure_servicebus_queue.rb
@@ -21,7 +21,17 @@ class AzureServicebusQueueTest < Test::Unit::TestCase
         timeToLive 60
     !
 
-    def create_driver(conf = CONFIG)
+    MSICONFIG = %q!
+    type azure_servicebus_queue
+    namespace test_namespace
+    queueName test_queue_name
+    format json
+    timeToLive 60
+    use_msi true
+    client_id abc
+!
+
+    def create_driver(conf)
         Fluent::Test::Driver::Output.new(Fluent::Plugin::AzureServicebusQueue) do
           # for testing.    
           def write(chunk)
@@ -36,12 +46,23 @@ class AzureServicebusQueueTest < Test::Unit::TestCase
     end
 
     def test_configure
-        d = create_driver
+        d = create_driver(CONFIG)
         assert_equal 'test_namespace', d.instance.namespace
         assert_equal 'test_queue_name', d.instance.queueName
         assert_equal 'send', d.instance.accessKeyName
         assert_equal '/etc/password/queuePassword', d.instance.accessKeyValueFile
         assert_equal 60, d.instance.timeToLive
         assert_equal 'message', d.instance.field
+    end
+
+
+    def test_msi_configure
+        d = create_driver(MSICONFIG)
+        assert_equal 'test_namespace', d.instance.namespace
+        assert_equal 'test_queue_name', d.instance.queueName
+        assert_equal 60, d.instance.timeToLive
+        assert_equal 'message', d.instance.field
+        assert_equal true, d.instance.use_msi
+        assert_equal 'abc', d.instance.client_id
     end
 end


### PR DESCRIPTION
for now, this plugin only supports accesskey. This pr will add msi support so that the user can use msi to get access to service bus queue